### PR TITLE
Feat/ownable signature executor

### DIFF
--- a/src/OwnableSignatureExecutor/OwnableSignatureExecutor.sol
+++ b/src/OwnableSignatureExecutor/OwnableSignatureExecutor.sol
@@ -17,7 +17,6 @@ import { OwnableExecutor } from "../OwnableExecutor/OwnableExecutor.sol";
 contract OwnableSignatureExecutor is OwnableExecutor, NonceManager {
     using SentinelListLib for SentinelListLib.SentinelList;
 
-    error InvalidChainId(uint256 chainId, uint256 expected);
     error InvalidNonce(uint256 nonce);
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -32,7 +31,6 @@ contract OwnableSignatureExecutor is OwnableExecutor, NonceManager {
      */
     function executeOnOwnedAccount(
         address ownedAccount,
-        uint256 chainId,
         uint256 nonce,
         bytes calldata callData,
         bytes calldata signature
@@ -40,14 +38,11 @@ contract OwnableSignatureExecutor is OwnableExecutor, NonceManager {
         external
         payable
     {
-        if (chainId != block.chainid) {
-            revert InvalidChainId(chainId, block.chainid);
-        }
         if (!_validateAndUpdateNonce(ownedAccount, nonce)) {
             revert InvalidNonce(nonce);
         }
 
-        bytes32 execHash = ECDSA.toEthSignedMessageHash(abi.encode(ownedAccount, chainId, nonce, msg.value, callData));
+        bytes32 execHash = ECDSA.toEthSignedMessageHash(abi.encode(ownedAccount, block.chainid, nonce, msg.value, callData));
         address owner = ECDSA.recoverCalldata(execHash, signature);
 
         // check if the signer is an owner
@@ -70,7 +65,6 @@ contract OwnableSignatureExecutor is OwnableExecutor, NonceManager {
      */
     function executeBatchOnOwnedAccount(
         address ownedAccount,
-        uint256 chainId,
         uint256 nonce,
         bytes calldata callData,
         bytes calldata signature
@@ -78,14 +72,11 @@ contract OwnableSignatureExecutor is OwnableExecutor, NonceManager {
         external
         payable
     {
-        if (chainId != block.chainid) {
-            revert InvalidChainId(chainId, block.chainid);
-        }
         if (!_validateAndUpdateNonce(ownedAccount, nonce)) {
             revert InvalidNonce(nonce);
         }
 
-        bytes32 execHash = ECDSA.toEthSignedMessageHash(abi.encode(ownedAccount, chainId, nonce, msg.value, callData));
+        bytes32 execHash = ECDSA.toEthSignedMessageHash(abi.encode(ownedAccount, block.chainid, nonce, msg.value, callData));
         address owner = ECDSA.recoverCalldata(execHash, signature);
 
         // check if the signer is an owner

--- a/src/OwnableSignatureExecutor/OwnableSignatureExecutor.sol
+++ b/src/OwnableSignatureExecutor/OwnableSignatureExecutor.sol
@@ -16,12 +16,13 @@ import { OwnableExecutor } from "../OwnableExecutor/OwnableExecutor.sol";
 contract OwnableSignatureExecutor is OwnableExecutor {
     using SentinelListLib for SentinelListLib.SentinelList;
 
+    error InvalidChainId(uint256 chainId, uint256 expected);
+
     /*//////////////////////////////////////////////////////////////////////////
                                      MODULE LOGIC
     //////////////////////////////////////////////////////////////////////////*/
 
     //TODO: Add nonce logic
-    //TODO: Add chainId replay protection logic
 
     /**
      * Executes a transaction on the owned account
@@ -32,13 +33,18 @@ contract OwnableSignatureExecutor is OwnableExecutor {
      */
     function executeOnOwnedAccount(
         address ownedAccount,
+        uint256 chainId,
         bytes calldata callData,
         bytes calldata signature
     )
         external
         payable
     {
-        bytes32 execHash = ECDSA.toEthSignedMessageHash(abi.encode(ownedAccount, msg.value, callData));
+        if (chainId != block.chainid) {
+            revert InvalidChainId(chainId, block.chainid);
+        }
+
+        bytes32 execHash = ECDSA.toEthSignedMessageHash(abi.encode(ownedAccount, chainId, msg.value, callData));
         address owner = ECDSA.recoverCalldata(execHash, signature);
 
         // check if the signer is an owner
@@ -61,13 +67,18 @@ contract OwnableSignatureExecutor is OwnableExecutor {
      */
     function executeBatchOnOwnedAccount(
         address ownedAccount,
+        uint256 chainId,
         bytes calldata callData,
         bytes calldata signature
     )
         external
         payable
     {
-        bytes32 execHash = ECDSA.toEthSignedMessageHash(abi.encode(ownedAccount, msg.value, callData));
+        if (chainId != block.chainid) {
+            revert InvalidChainId(chainId, block.chainid);
+        }
+
+        bytes32 execHash = ECDSA.toEthSignedMessageHash(abi.encode(ownedAccount, chainId, msg.value, callData));
         address owner = ECDSA.recoverCalldata(execHash, signature);
 
         // check if the signer is an owner

--- a/src/OwnableSignatureExecutor/OwnableSignatureExecutor.sol
+++ b/src/OwnableSignatureExecutor/OwnableSignatureExecutor.sol
@@ -26,6 +26,7 @@ contract OwnableSignatureExecutor is OwnableExecutor, NonceManager {
      * Executes a transaction on the owned account
      *
      * @param ownedAccount address of the account to execute the transaction on
+     * @param nonce 2D Nonce (similar to ERC4337) to enable transaction ordering
      * @param callData encoded data containing the transaction to execute
      * @param signature encoded signature of ownedAccount, msg.value, callData
      */
@@ -60,6 +61,7 @@ contract OwnableSignatureExecutor is OwnableExecutor, NonceManager {
      * Executes a batch of transactions on the owned account
      *
      * @param ownedAccount address of the account to execute the transaction on
+     * @param nonce 2D Nonce (similar to ERC4337) to enable transaction ordering
      * @param callData encoded data containing the transactions to execute
      * @param signature encoded signature of ownedAccount, msg.value, callData
      */

--- a/src/OwnableSignatureExecutor/OwnableSignatureExecutor.sol
+++ b/src/OwnableSignatureExecutor/OwnableSignatureExecutor.sol
@@ -10,8 +10,8 @@ import { OwnableExecutor } from "../OwnableExecutor/OwnableExecutor.sol";
 
 /**
  * @title OwnableSignatureExecutor
- * @dev Module that allows users to designate an owner that can execute transactions on their behalf using msg.sender, EIP191, EIP712
- * and pays for gas. Signature based transactions have their own internal shared nonce counter
+ * @dev Module that allows users to designate an owner that can execute transactions on their behalf using msg.sender or EIP191 signatures,
+ * and pays for gas. Signature based transactions have their own internal shared nonce counter, validUntil and validAfter timestamps.
  * @author Leo Vigna
  */
 contract OwnableSignatureExecutor is OwnableExecutor, NonceManager {

--- a/src/OwnableSignatureExecutor/OwnableSignatureExecutor.sol
+++ b/src/OwnableSignatureExecutor/OwnableSignatureExecutor.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.25;
 
-import { IERC7579Account } from "modulekit/accounts/common/interfaces/IERC7579Account.sol";
-import { ECDSA } from "solady/utils/ECDSA.sol";
-import { ModeLib } from "modulekit/accounts/common/lib/ModeLib.sol";
-import { SentinelListLib } from "sentinellist/SentinelList.sol";
-import { NonceManager } from "@ERC4337/account-abstraction/contracts/core/NonceManager.sol";
-import { OwnableExecutor } from "../OwnableExecutor/OwnableExecutor.sol";
+import {IERC7579Account} from "modulekit/accounts/common/interfaces/IERC7579Account.sol";
+import {ECDSA} from "solady/utils/ECDSA.sol";
+import {ModeLib} from "modulekit/accounts/common/lib/ModeLib.sol";
+import {SentinelListLib} from "sentinellist/SentinelList.sol";
+import {NonceManager} from "@ERC4337/account-abstraction/contracts/core/NonceManager.sol";
+import {OwnableExecutor} from "../OwnableExecutor/OwnableExecutor.sol";
 
 /**
  * @title OwnableSignatureExecutor
@@ -37,24 +37,29 @@ contract OwnableSignatureExecutor is OwnableExecutor, NonceManager {
         address ownedAccount,
         uint256 nonce,
         uint48 validAfter,
-        uint48 validUntil, 
+        uint48 validUntil,
         bytes calldata callData,
         bytes calldata signature
-    )
-        external
-        payable
-    {
-
+    ) external payable {
         if (block.timestamp > validUntil || block.timestamp < validAfter) {
-            revert InvalidTimestamp(validUntil, validAfter);   
+            revert InvalidTimestamp(validUntil, validAfter);
         }
 
         if (!_validateAndUpdateNonce(ownedAccount, nonce)) {
             revert InvalidNonce(nonce);
         }
 
-
-        bytes32 execHash = ECDSA.toEthSignedMessageHash(abi.encode(block.chainid, ownedAccount, nonce, validAfter, validUntil, msg.value, callData));
+        bytes32 execHash = ECDSA.toEthSignedMessageHash(
+            abi.encode(
+                block.chainid,
+                ownedAccount,
+                nonce,
+                validAfter,
+                validUntil,
+                msg.value,
+                callData
+            )
+        );
         address owner = ECDSA.recoverCalldata(execHash, signature);
 
         // check if the signer is an owner
@@ -63,8 +68,9 @@ contract OwnableSignatureExecutor is OwnableExecutor, NonceManager {
         }
 
         // execute the transaction on the owned account
-        IERC7579Account(ownedAccount).executeFromExecutor{ value: msg.value }(
-            ModeLib.encodeSimpleSingle(), callData
+        IERC7579Account(ownedAccount).executeFromExecutor{value: msg.value}(
+            ModeLib.encodeSimpleSingle(),
+            callData
         );
     }
 
@@ -81,23 +87,30 @@ contract OwnableSignatureExecutor is OwnableExecutor, NonceManager {
     function executeBatchOnOwnedAccount(
         address ownedAccount,
         uint256 nonce,
-        uint48 validAfter, 
+        uint48 validAfter,
         uint48 validUntil,
         bytes calldata callData,
         bytes calldata signature
-    )
-        external
-        payable
-    {
+    ) external payable {
         if (block.timestamp > validUntil || block.timestamp < validAfter) {
-            revert InvalidTimestamp(validUntil, validAfter);   
+            revert InvalidTimestamp(validUntil, validAfter);
         }
 
         if (!_validateAndUpdateNonce(ownedAccount, nonce)) {
             revert InvalidNonce(nonce);
         }
 
-        bytes32 execHash = ECDSA.toEthSignedMessageHash(abi.encode(block.chainid, ownedAccount, nonce, validAfter, validUntil, msg.value, callData));
+        bytes32 execHash = ECDSA.toEthSignedMessageHash(
+            abi.encode(
+                block.chainid,
+                ownedAccount,
+                nonce,
+                validAfter,
+                validUntil,
+                msg.value,
+                callData
+            )
+        );
         address owner = ECDSA.recoverCalldata(execHash, signature);
 
         // check if the signer is an owner
@@ -106,8 +119,9 @@ contract OwnableSignatureExecutor is OwnableExecutor, NonceManager {
         }
 
         // execute the batch of transaction on the owned account
-        IERC7579Account(ownedAccount).executeFromExecutor{ value: msg.value }(
-            ModeLib.encodeSimpleBatch(), callData
+        IERC7579Account(ownedAccount).executeFromExecutor{value: msg.value}(
+            ModeLib.encodeSimpleBatch(),
+            callData
         );
     }
 
@@ -119,7 +133,7 @@ contract OwnableSignatureExecutor is OwnableExecutor, NonceManager {
      *
      * @return name of the module
      */
-    function name() external override pure virtual returns (string memory) {
+    function name() external pure virtual override returns (string memory) {
         return "OwnableSignatureExecutor";
     }
 }

--- a/src/OwnableSignatureExecutor/OwnableSignatureExecutor.sol
+++ b/src/OwnableSignatureExecutor/OwnableSignatureExecutor.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.25;
+
+import { OwnableExecutor } from "../OwnableExecutor/OwnableExecutor.sol";
+
+/**
+ * @title OwnableSignatureExecutor
+ * @dev Module that allows users to designate an owner that can execute transactions on their behalf using msg.sender, EIP191, EIP712
+ * and pays for gas. Signature based transactions have their own internal shared nonce counter
+ * @author Leo Vigna
+ */
+contract OwnableSignatureExecutor is OwnableExecutor {
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     MODULE LOGIC
+    //////////////////////////////////////////////////////////////////////////*/
+
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     METADATA
+    //////////////////////////////////////////////////////////////////////////*/
+    /**
+     * Returns the name of the module
+     *
+     * @return name of the module
+     */
+    function name() external override pure virtual returns (string memory) {
+        return "OwnableSignatureExecutor";
+    }
+}


### PR DESCRIPTION
Add OwnableSingatureExecutor, enables usage of ERC7579 account using simple signatures without need to go through EntryPoint